### PR TITLE
Updates the link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The starting point was `resource/resource.js`, taken from here:
 The original data in `resource/reporters.js` and `resource/courts.json`
 was collected, collated and organized by the Free Law Project:
 
-   https://github.com/mlissner/courtlistener/blob/master/alert/citations/constants.py
+   https://github.com/freelawproject/reporters-db/blob/master/reporters.json
 
 `mlz_jurisdiction` keys are added to the `resource/courts.json` object by the
 `resource/COURTS.py` script, and written to `resource/courts-new.json`


### PR DESCRIPTION
The one that was in here is to a random one-off copy of the repo that I should probably delete (and will soon). Instead I put it to reporters.json, which isn't right either, but is at least more likely to be around for a little while.
